### PR TITLE
Add the ability to block specific spawn reasons from being randomized.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'com.autcraft'
-version = '1.1.1'
+version = '1.1.2'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/autcraft/mobsizerandomizer/events/SpawnEvent.java
+++ b/src/main/java/com/autcraft/mobsizerandomizer/events/SpawnEvent.java
@@ -4,6 +4,7 @@ import com.autcraft.mobsizerandomizer.MobSizeRandomizer;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.CreatureSpawnEvent;
+import org.jetbrains.annotations.NotNull;
 
 public class SpawnEvent implements Listener {
     private final MobSizeRandomizer plugin;
@@ -15,8 +16,22 @@ public class SpawnEvent implements Listener {
     @EventHandler
     public void onSpawnEvent(CreatureSpawnEvent event) {
         // Adjust scale of mob if not in an excluded world
-        if (!plugin.isExcludedWorld(event.getLocation().getWorld().getName())) {
+        if (!plugin.isExcludedWorld(event.getLocation().getWorld().getName()) && canSpawnReasonBeScaled(event)) {
             plugin.scaleMob(event.getEntity());
         }
+    }
+
+    /**
+     * Checks to see if the provided {@link CreatureSpawnEvent} can have the mob scale adjusted based
+     * on the {@link CreatureSpawnEvent.SpawnReason} block list.
+     *
+     * @param event The {@link CreatureSpawnEvent} to check.
+     * @return {@code true} if the provided {@link CreatureSpawnEvent} can have the mob scale adjusted.
+     */
+    private boolean canSpawnReasonBeScaled(@NotNull CreatureSpawnEvent event) {
+        if (plugin.isSpawnReasonBlocklistEnabled()) {
+            return !plugin.getBlockedSpawnReasons().contains(event.getSpawnReason());
+        }
+        return true;
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,14 @@
 debug: false
 
+# If you want to prevent specific spawn reasons from changing mob size, set this to true
+enable-spawn-reason-blocklist: false
+# If the blocklist is enabled, any spawn reason included here will be excluded from having mob size randomized
+# See https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/event/entity/CreatureSpawnEvent.SpawnReason.html for
+# all possible options.
+spawn-reasons-blocklist:
+  - SPAWNER_EGG
+  - SPAWNER
+
 
 # Default sizes will work for ALL LIVING ENTITIES that spawn
 # If you want certain mobs to not change in size, list them below with max and min set to 1 (their default size)


### PR DESCRIPTION
This PR adds the ability to block specific spawn reasons from being randomized. This is useful as plugins like SafariNets that lets you captures mobs will have the mob's size randomized each time they are captured and uncaptured which leads to an inconsistent experience with players.

This setting is disabled by default, and will require users to add the configuration sections to the config themselves if they'd like to utilize this.