### PR TITLE
Add ability to hook into Lands

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'com.autcraft'
-version = '1.1.2'
+version = '1.1.3'
 
 repositories {
     mavenCentral()
@@ -15,10 +15,15 @@ repositories {
         name = "sonatype"
         url = "https://oss.sonatype.org/content/groups/public/"
     }
+    maven {
+        name = "jitpack"
+        url = 'https://jitpack.io'
+    }
 }
 
 dependencies {
     compileOnly "io.papermc.paper:paper-api:1.20.6-R0.1-SNAPSHOT"
+    compileOnly("com.github.angeschossen:LandsAPI:7.13.1") // Lands
 }
 
 def targetJavaVersion = 21

--- a/src/main/java/com/autcraft/mobsizerandomizer/MobSizeRandomizer.java
+++ b/src/main/java/com/autcraft/mobsizerandomizer/MobSizeRandomizer.java
@@ -2,13 +2,16 @@ package com.autcraft.mobsizerandomizer;
 
 import com.autcraft.mobsizerandomizer.commands.MainCommands;
 import com.autcraft.mobsizerandomizer.events.SpawnEvent;
+import com.autcraft.mobsizerandomizer.external.LandsHook;
 import com.google.common.collect.ImmutableSet;
+import org.bukkit.Bukkit;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -24,6 +27,10 @@ public final class MobSizeRandomizer extends JavaPlugin {
     // Spawn reason blocklist
     private boolean spawnReasonBlocklistEnabled = false;
     private Set<CreatureSpawnEvent.SpawnReason> blockedSpawnReasons = new HashSet<>();
+
+    // Lands integration
+    @Nullable
+    private LandsHook landsHook;
 
     @Override
     public void onEnable() {
@@ -42,6 +49,11 @@ public final class MobSizeRandomizer extends JavaPlugin {
         saveConfig();
     }
 
+    @Override
+    public void onLoad() {
+        setupLoadHooks();
+    }
+
     /**
      * Load values from config.yml
      */
@@ -57,6 +69,13 @@ public final class MobSizeRandomizer extends JavaPlugin {
         setBlockedSpawnReasons(getConfig().getStringList("spawn-reasons-blocklist").stream().map(CreatureSpawnEvent.SpawnReason::valueOf).collect(Collectors.toSet()));
 
         setExcludedWorlds();
+    }
+
+    private void setupLoadHooks() {
+        if (Bukkit.getPluginManager().getPlugin("Lands") != null) {
+            landsHook = new LandsHook(this);
+            getLogger().info("Lands Integration loaded.");
+        }
     }
 
     /**
@@ -167,6 +186,18 @@ public final class MobSizeRandomizer extends JavaPlugin {
      */
     public void setBlockedSpawnReasons(@NotNull Set<CreatureSpawnEvent.SpawnReason> blockedSpawnReasons) {
         this.blockedSpawnReasons = blockedSpawnReasons;
+    }
+
+    /**
+     * Gets the {@link LandsHook} MobSizeRandomizer uses to support Lands.
+     *
+     * @return An {@link Optional} containing the {@link LandsHook} MobSizeRandomizer uses to support
+     * <a href="https://www.spigotmc.org/resources/lands-%E2%AD%95-land-claim-plugin-%E2%9C%85-grief-prevention-protection-gui-management-nations-wars-1-21-support.53313/">Lands</a>
+     * if Lands is running.
+     */
+    @NotNull
+    public Optional<LandsHook> getLandsHook() {
+        return Optional.ofNullable(landsHook);
     }
 
     /**

--- a/src/main/java/com/autcraft/mobsizerandomizer/events/SpawnEvent.java
+++ b/src/main/java/com/autcraft/mobsizerandomizer/events/SpawnEvent.java
@@ -16,7 +16,7 @@ public class SpawnEvent implements Listener {
     @EventHandler
     public void onSpawnEvent(CreatureSpawnEvent event) {
         // Adjust scale of mob if not in an excluded world
-        if (!plugin.isExcludedWorld(event.getLocation().getWorld().getName()) && canSpawnReasonBeScaled(event)) {
+        if (!plugin.isExcludedWorld(event.getLocation().getWorld().getName()) && canSpawnReasonBeScaled(event) && canSpawnBeScaledInLands(event)) {
             plugin.scaleMob(event.getEntity());
         }
     }
@@ -33,5 +33,16 @@ public class SpawnEvent implements Listener {
             return !plugin.getBlockedSpawnReasons().contains(event.getSpawnReason());
         }
         return true;
+    }
+
+    /**
+     * Checks to see if the provided {@link CreatureSpawnEvent} can have the mob scale adjusted
+     * based on if the spawn happened in a {@link me.angeschossen.lands.api.land.Land} or not.
+     *
+     * @param event The {@link CreatureSpawnEvent} to check.
+     * @return {@code true} if the provided {@link CreatureSpawnEvent} can have the mob scale adjusted.
+     */
+    private boolean canSpawnBeScaledInLands(@NotNull CreatureSpawnEvent event) {
+        return plugin.getLandsHook().map(landsHook -> landsHook.doesLandAllowSizeRandomization(event.getLocation())).orElse(true);
     }
 }

--- a/src/main/java/com/autcraft/mobsizerandomizer/external/LandsHook.java
+++ b/src/main/java/com/autcraft/mobsizerandomizer/external/LandsHook.java
@@ -1,0 +1,127 @@
+package com.autcraft.mobsizerandomizer.external;
+
+import com.autcraft.mobsizerandomizer.MobSizeRandomizer;
+import me.angeschossen.lands.api.LandsIntegration;
+import me.angeschossen.lands.api.flags.enums.FlagTarget;
+import me.angeschossen.lands.api.flags.type.NaturalFlag;
+import me.angeschossen.lands.api.land.Area;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * A hook for containing all code related to <a href="https://www.spigotmc.org/resources/lands-%E2%AD%95-land-claim-plugin-%E2%9C%85-grief-prevention-protection-gui-management-nations-wars-1-21-support.53313/">Lands</a>
+ * that McMobSizeRandomizerRPG needs in order to support it.
+ */
+public class LandsHook {
+
+    private static final ItemStack flagIcon;
+
+    static {
+        flagIcon = new ItemStack(Material.ZOMBIE_HORSE_SPAWN_EGG);
+    }
+
+    private final MobSizeRandomizer plugin;
+    private final LandsIntegration landsIntegration;
+    private NaturalFlag randomizeFlag;
+
+    public LandsHook(@NotNull MobSizeRandomizer plugin) {
+        this.plugin = plugin;
+        this.landsIntegration = LandsIntegration.of(plugin);
+        landsIntegration.onLoad(this::setupFlag);
+    }
+
+    private void setupFlag() {
+        randomizeFlag = NaturalFlag.of(landsIntegration, FlagTarget.PLAYER, "random_mob_size");
+        randomizeFlag.setDefaultState(true)
+                .setApplyInSubareas(true)
+                .setActiveInWar(true)
+                .setDisplay(true)
+                .setDisplayName("Enable Randomizing Mob Size")
+                .setDescription(List.of("Will allow mobs that spawn to have their size", "randomized while within your land."))
+                .setIcon(flagIcon);
+    }
+
+    /**
+     * Checks to see if the provided {@link Player} is standing in is an {@link Area}
+     * that they own.
+     *
+     * @param player The {@link Player} to check.
+     * @return {@code true} if the provided player is standing in an {@link Area} that
+     * they own.
+     */
+    public boolean isPlayerStandingInOwnedLand(@NotNull Player player) {
+        Area area = landsIntegration.getArea(player.getLocation());
+        if (area != null) {
+            return area.getOwnerUID().equals(player.getUniqueId());
+        }
+        return false;
+    }
+
+    /**
+     * Checks to see if the provided {@link Player} is standing in an {@link Area} that
+     * they are trusted in.
+     *
+     * @param player The {@link Player} to check.
+     * @return {@code true} if the provided player is standing in an {@link Area} that they are
+     * trusted in.
+     */
+    public boolean isPlayerStandingInTrustedLand(@NotNull Player player) {
+        Area area = landsIntegration.getArea(player.getLocation());
+        if (area != null) {
+            return area.isTrusted(player.getUniqueId());
+        }
+        return false;
+    }
+
+    /**
+     * Checks to see if the provided {@link Player} is standing in an {@link Area} that
+     * they are a tenant of.
+     *
+     * @param player The {@link Player} to check.
+     * @return {@code true} if the provided player is standing in an {@link Area} that they
+     * are a tenant of.
+     */
+    public boolean isPlayerStandingInTenantLand(@NotNull Player player) {
+        Area area = landsIntegration.getArea(player.getLocation());
+        if (area != null && area.getTenant() != null) {
+            return area.getTenant() == player.getUniqueId();
+        }
+        return false;
+    }
+
+    /**
+     * Checks to see if the {@link Player} is currently standing in an {@link Area}.
+     *
+     * @param player The {@link Player} to check.
+     * @return {@code true} if the provided {@link Player} is standing in an {@link Area}.
+     */
+    public boolean isPlayerStandingInLand(@NotNull Player player) {
+        return isLocationInLand(player.getLocation());
+    }
+
+    /**
+     * Checks to see if the {@link Location} is currently in an {@link Area}.
+     *
+     * @param location The {@link Location} to check.
+     * @return {@code true} if the provided {@link Location} is in an {@link Area}.
+     */
+    public boolean isLocationInLand(@NotNull Location location) {
+        return landsIntegration.getArea(location) != null;
+    }
+
+    /**
+     * Checks to see if the land belonging to the provided {@link Location} allows mob size randomization.
+     *
+     * @param location The {@link Location} to check.
+     * @return {@code true} if the land belonging to the provided {@link Location} allows mob size randomization.
+     */
+    public boolean doesLandAllowSizeRandomization(@NotNull Location location) {
+        Area area = landsIntegration.getArea(location);
+        return area == null || area.hasNaturalFlag(randomizeFlag);
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,8 @@ name: MobSizeRandomizer
 version: '${version}'
 main: com.autcraft.mobsizerandomizer.MobSizeRandomizer
 api-version: '1.20'
-load: STARTUP
+load: POSTWORLD # Needs to be post world to support lands
+softdepend: [Lands]
 commands:
   mobsizerandomizer:
     description: Main Command


### PR DESCRIPTION
Add the ability to hook into Lands to allow players to toggle size randomization in their areas as users complained about mob farms breaking.

- Will be displayed as a toggleable flag that users can turn on and off
- Defaults to allow mob size randomization in a Land to not break existing behavior
- Server owners will need to add `random_mob_size` to the list of flags in the `display_list` part of the Lands config in order for it to be shown in the flag GUI.